### PR TITLE
cicd: switching over to ubuntu from alpine for dcos-cli

### DIFF
--- a/resources/com/mesosphere/global/terraform_file_deploy.sh
+++ b/resources/com/mesosphere/global/terraform_file_deploy.sh
@@ -8,7 +8,7 @@ function build_task() {
   eval "$(ssh-agent)"; if [[ ! -f "$PWD/ssh-key" ]]; then rm ssh-key.pub; ssh-keygen -t rsa -b 4096 -f $PWD/ssh-key -P ''; fi; ssh-add $PWD/ssh-key
   terraform init
   ./deploy.cmd || exit 1 # Deploy
-  # deploy_test_app # disabling the test for the time being
+  deploy_test_app # deploying mlb and nginx test
   ./expand.cmd || exit 1 # Expand
   ./upgrade.cmd || exit 1 # Upgrade
 }


### PR DESCRIPTION
The test was not passing previously due to the missing libraries that were required by the dcos-cli. I moved from alpine that was using musl libc to ubuntu using glibc. After confirming that the libraries were present and working for the dcos-cli, I promoted the dcos-terraform-cicd to version 1.0.4 and it works successfully running the test cicd scripts.

We're safe to enable this test as jenkins is ready to use the new container with the new operating system.

Here is the dockerfil https://github.com/bernadinm/dcos-terraform-cicd/tree/ubuntu